### PR TITLE
Normalised Image Orientation

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -602,9 +602,9 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
     [originalImage drawInRect:CGRectMake(-originalImage.size.width / 2.0f, -originalImage.size.height / 2.0f, originalImage.size.width, originalImage.size.height)];
     
     // Save image
-    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIImage *normalizedImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    return newImage;
+    return normalizedImage;
 }
 
 -(void)changeCamera:(CallbackBlock)block

--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -22,6 +22,8 @@
 #import "CKCameraOverlayView.h"
 #import "CKGalleryManager.h"
 
+#define DEGREES_TO_RADIANS(angle) (angle / 180.0 * M_PI)
+
 static void * CapturingStillImageContext = &CapturingStillImageContext;
 static void * SessionRunningContext = &SessionRunningContext;
 

--- a/ios/lib/ReactNativeCameraKit/CKCamera.m
+++ b/ios/lib/ReactNativeCameraKit/CKCamera.m
@@ -565,6 +565,10 @@ RCT_ENUM_CONVERTER(CKCameraZoomMode, (@{
 }
 
 +(UIImage*)normalizeImage:(UIImage*)originalImage {
+    if (originalImage == nil) {
+        return originalImage;
+    }
+    
     CGFloat rotation = DEGREES_TO_RADIANS(0);
     
     switch(UIDevice.currentDevice.orientation)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "5.3.21",
+  "version": "5.3.22",
   "description": "Advanced native camera control with pre-defined aspect ratio, crop, etc",
   "author": "Ran Greenberg <rang@wix.com>",
   "nativePackage": true,


### PR DESCRIPTION
This PR resolves the issue where photos taken in landscape left, landscape right and portrait upside down result in the images being displayed at an unwanted 90 degree rotation. To invert the unwanted rotation, I have rotated the images by 90 degree in the opposite rotation direction.